### PR TITLE
jax==0.3.25 is not compatible with the latest chex

### DIFF
--- a/install_colabbatch_linux.sh
+++ b/install_colabbatch_linux.sh
@@ -27,7 +27,7 @@ conda install -c conda-forge -c bioconda kalign2=2.04 hhsuite=3.3.0 mmseqs2=14.7
 colabfold-conda/bin/python3.9 -m pip install --upgrade pip
 colabfold-conda/bin/python3.9 -m pip install --no-warn-conflicts "colabfold[alphafold-minus-jax] @ git+https://github.com/sokrypton/ColabFold"
 colabfold-conda/bin/python3.9 -m pip install https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.25+cuda11.cudnn82-cp39-cp39-manylinux2014_x86_64.whl
-colabfold-conda/bin/python3.9 -m pip install jax==0.3.25 biopython==1.79
+colabfold-conda/bin/python3.9 -m pip install jax==0.3.25 chex==0.1.6 biopython==1.79
 
 # Use 'Agg' for non-GUI backend
 cd ${COLABFOLDDIR}/colabfold-conda/lib/python3.9/site-packages/colabfold


### PR DESCRIPTION
`jax==0.3.25` is not compatible with the latest `chex==0.1.7` ,  We need to keep it in the lower version (`chex==0.1.7`).